### PR TITLE
fixed commands in readme for four nodes

### DIFF
--- a/versions/8.10.0/README.md
+++ b/versions/8.10.0/README.md
@@ -229,7 +229,7 @@ data-center/master/versions/8.10.0/docker-compose-four-nodes.yml"
 
 cp -R /opt/jira-cluster/8.10.0/jira-home-node1/{data,plugins,logos,import,export,caches} /opt/jira-cluster/8.10.0/jira-home-node4
 docker-compose -f docker-compose-four-nodes.yml up -d
-docker-compose -f docker-compose-three-nodes.yml restart jira-cluster-8100-lb
+docker-compose -f docker-compose-four-nodes.yml restart jira-cluster-8100-lb
 ```
 
 To check call this multiple times, and it should output the different node ids after some time

--- a/versions/8.11.0/README.md
+++ b/versions/8.11.0/README.md
@@ -229,7 +229,7 @@ data-center/master/versions/8.11.0/docker-compose-four-nodes.yml"
 
 cp -R /opt/jira-cluster/8.11.0/jira-home-node1/{data,plugins,logos,import,export,caches} /opt/jira-cluster/8.11.0/jira-home-node4
 docker-compose -f docker-compose-four-nodes.yml up -d
-docker-compose -f docker-compose-three-nodes.yml restart jira-cluster-8110-lb
+docker-compose -f docker-compose-four-nodes.yml restart jira-cluster-8110-lb
 ```
 
 To check call this multiple times, and it should output the different node ids after some time

--- a/versions/8.4.0/README.md
+++ b/versions/8.4.0/README.md
@@ -230,7 +230,7 @@ data-center/master/versions/8.4.0/docker-compose-four-nodes.yml"
 
 cp -R /opt/jira-cluster/8.4.0/jira-home-node1/{data,plugins,logos,import,export,caches} /opt/jira-cluster/8.4.0/jira-home-node4
 docker-compose -f docker-compose-four-nodes.yml up -d
-docker-compose -f docker-compose-three-nodes.yml restart jira-cluster-840-lb
+docker-compose -f docker-compose-four-nodes.yml restart jira-cluster-840-lb
 ```
 
 To check call this multiple times, and it should output the different node ids after some time

--- a/versions/8.5.0/README.md
+++ b/versions/8.5.0/README.md
@@ -230,7 +230,7 @@ data-center/master/versions/8.5.0/docker-compose-four-nodes.yml"
 
 cp -R /opt/jira-cluster/8.5.0/jira-home-node1/{data,plugins,logos,import,export,caches} /opt/jira-cluster/8.5.0/jira-home-node4
 docker-compose -f docker-compose-four-nodes.yml up -d
-docker-compose -f docker-compose-three-nodes.yml restart jira-cluster-850-lb
+docker-compose -f docker-compose-four-nodes.yml restart jira-cluster-850-lb
 ```
 
 To check call this multiple times, and it should output the different node ids after some time

--- a/versions/8.6.0/README.md
+++ b/versions/8.6.0/README.md
@@ -231,7 +231,7 @@ data-center/master/versions/8.6.0/docker-compose-four-nodes.yml"
 
 cp -R /opt/jira-cluster/8.6.0/jira-home-node1/{data,plugins,logos,import,export,caches} /opt/jira-cluster/8.6.0/jira-home-node4
 docker-compose -f docker-compose-four-nodes.yml up -d
-docker-compose -f docker-compose-three-nodes.yml restart jira-cluster-860-lb
+docker-compose -f docker-compose-four-nodes.yml restart jira-cluster-860-lb
 ```
 
 To check call this multiple times, and it should output the different node ids after some time

--- a/versions/8.7.0/README.md
+++ b/versions/8.7.0/README.md
@@ -228,7 +228,7 @@ curl -so docker-compose-four-nodes.yml \
 data-center/master/versions/8.7.0/docker-compose-four-nodes.yml"
 
 docker-compose -f docker-compose-four-nodes.yml up -d
-docker-compose -f docker-compose-three-nodes.yml restart jira-cluster-870-lb
+docker-compose -f docker-compose-four-nodes.yml restart jira-cluster-870-lb
 ```
 
 To check call this multiple times, and it should output the different node ids after some time

--- a/versions/8.8.0/README.md
+++ b/versions/8.8.0/README.md
@@ -229,7 +229,7 @@ data-center/master/versions/8.8.0/docker-compose-four-nodes.yml"
 
 cp -R /opt/jira-cluster/8.8.0/jira-home-node1/{data,plugins,logos,import,export,caches} /opt/jira-cluster/8.8.0/jira-home-node4
 docker-compose -f docker-compose-four-nodes.yml up -d
-docker-compose -f docker-compose-three-nodes.yml restart jira-cluster-880-lb
+docker-compose -f docker-compose-four-nodes.yml restart jira-cluster-880-lb
 ```
 
 To check call this multiple times, and it should output the different node ids after some time

--- a/versions/8.9.0/README.md
+++ b/versions/8.9.0/README.md
@@ -229,7 +229,7 @@ data-center/master/versions/8.9.0/docker-compose-four-nodes.yml"
 
 cp -R /opt/jira-cluster/8.9.0/jira-home-node1/{data,plugins,logos,import,export,caches} /opt/jira-cluster/8.9.0/jira-home-node4
 docker-compose -f docker-compose-four-nodes.yml up -d
-docker-compose -f docker-compose-three-nodes.yml restart jira-cluster-890-lb
+docker-compose -f docker-compose-four-nodes.yml restart jira-cluster-890-lb
 ```
 
 To check call this multiple times, and it should output the different node ids after some time


### PR DESCRIPTION
The readme contained an error which referenced the wrong docker-compose yml file when four nodes are being used.